### PR TITLE
Remove 'Expect: 100-Continue' request header when uploading bits

### DIFF
--- a/commands/push.go
+++ b/commands/push.go
@@ -97,7 +97,7 @@ func Push(cliConnection plugin.CliConnection, args []string) {
 		zipper := appfiles.ApplicationZipper{}
 		fileutils.TempFile("uploads", func(zipFile *os.File, err error) {
 			zipper.Zip(appDir, zipFile)
-			_, upload := exec.Command("curl", fmt.Sprintf("%s/v3/packages/%s/upload", apiString, pack.Guid), "-F", fmt.Sprintf("bits=@%s", zipFile.Name()), "-H", fmt.Sprintf("Authorization: %s", token)).Output()
+			_, upload := exec.Command("curl", fmt.Sprintf("%s/v3/packages/%s/upload", apiString, pack.Guid), "-F", fmt.Sprintf("bits=@%s", zipFile.Name()), "-H", fmt.Sprintf("Authorization: %s", token), "-H", "Expect:").Output()
 			FreakOut(upload)
 		})
 

--- a/v3.go
+++ b/v3.go
@@ -74,7 +74,7 @@ func (v3plugin *V3Plugin) GetMetadata() plugin.PluginMetadata {
 		Version: plugin.VersionType{
 			Major: 0,
 			Minor: 6,
-			Build: 6,
+			Build: 7,
 		},
 		Commands: []plugin.Command{
 			{


### PR DESCRIPTION
Some infrastructures (notably Google Cloud Platform when using an HTTP load balancer)
reject 100 Continue responses and instead return a 502. By removing the Expect header
when uploading bits, the v3-plugin can work with Cloud Foundries installed on
Google Cloud Platform.
